### PR TITLE
New deleteAtEnd option

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ npm install @devraelfreeze/discordjs-pagination
 | `author`            |                              `User`                              | Author's user class                                                                                |
 | `buttons`           |                           `Buttons[]`                            | Customization of your buttons <br />*See examples below*                                           |
 | `disableButtons`    |                            `boolean`                             | Disable or remove buttons after timeout (true = disable, false = remove)                           |
+| `deleteAtEnd`       |                            `boolean`                             | Delete or not the embed or message after timeout (true = remove, false = keep)                     |
 | `pageTravel`        |                            `boolean`                             | Travel pages by sending page numbers (With Modal Interaction)                                      |
 | `fastSkip`          |                            `boolean`                             | Create two additional buttons, a button to skip to the end and a button to skip to the first page  |
 | `time`              |                             `number`                             | How long before pagination get disabled **(in ms)**                                                |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devraelfreeze/discordjs-pagination",
-  "version": "2.7.4",
+  "version": "2.7.5",
   "description": "A pagination module for Discord.js v14",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/pagination/pagination.i.ts
+++ b/src/pagination/pagination.i.ts
@@ -41,6 +41,11 @@ export interface PaginationOptions {
     * Disable or remove buttons after timeout
     */
    disableButtons?: boolean
+
+   /**
+     * Delete or not the embed or message after timeout
+     */
+   deleteAtEnd?: boolean;
    
    /**
     * travel pages by sending page numbers?

--- a/src/pagination/pagination.ts
+++ b/src/pagination/pagination.ts
@@ -35,6 +35,7 @@ export const pagination = async (options: PaginationOptions) => {
       ephemeral,
       author,
       disableButtons,
+      deleteAtEnd,
       embeds,
       buttons,
       time,
@@ -209,13 +210,26 @@ export const pagination = async (options: PaginationOptions) => {
    
    collector.on("end", () => {
       if (type === 'message') {
-         initialMessage.edit({
-            components: disableB ? components(true) : []
-         });
-      } else {
-         interaction.editReply({
-            components: disableB ? components(true) : []
-         });
+         if (deleteAtEnd) {
+            initialMessage.delete()
+                  .catch(() => ({}));
+         }
+         else {
+            initialMessage.edit({
+                  components: disableB ? components(true) : []
+            }).catch(() => ({}));
+         }
+      }
+      else {
+         if (deleteAtEnd) {
+            interaction.deleteReply()
+                  .catch(() => ({}));
+         }
+         else {
+            interaction.editReply({
+                  components: disableB ? components(true) : []
+            }).catch(() => ({}));
+         }
       }
    });
 }


### PR DESCRIPTION
Here's a new option: `deleteAtEnd`, which deletes the paginated embed (or message) at the end of the timer.

I've also added the `catch` we discussed in [this topic](https://github.com/devRael1/discordjs-pagination/issues/12).