### PR TITLE
fix(types): Allow passing EmbedBuilder or APIEmbed data directly with…

### DIFF
--- a/src/pagination/pagination.i.ts
+++ b/src/pagination/pagination.i.ts
@@ -1,6 +1,7 @@
-import {
+import type {
    Client,
-   Embed,
+   APIEmbed,
+   JSONEncodable,
    Message,
    User,
    MessageComponentInteraction,
@@ -36,7 +37,7 @@ export interface PaginationOptions {
    /**
     * array of embed messages to paginate
     */
-   embeds: Embed[]
+   embeds: (APIEmbed | JSONEncodable<APIEmbed>)[]
    
    /**
     * customize your buttons!


### PR DESCRIPTION
…out type errors

Before, when using the paginate function, you had to pass an Embed object directly. With this implementation, you can pass an embed, but you can also pass an EmbedBuilder, or Embed API data directly, without receiving a TypeScript error.